### PR TITLE
Add go test frameworks

### DIFF
--- a/AnyTest.sublime-settings
+++ b/AnyTest.sublime-settings
@@ -7,6 +7,7 @@
             "exunit"
         ],
         "go": [
+            "delve",
             "ginkgo",
             "gotest",
         ],
@@ -95,13 +96,13 @@
     // "go.runner": "command", // a runner for all Go test frameworks
     // "go.env": { "ENV1": "value" }, // will be merged with the ENV variable defined on the test framework level
     //
-    // "go.gotest.runner": "command", // a runner for the Gotest test framework
-    "go.gotest.executable": [
-        "go",
+    // "go.delve.runner": "command", // a runner for the Delve test framework
+    "go.delve.executable": [
+        "dlv",
         "test"
-    ], // for richgo use ["richgo", "test"]
-    // "go.gotest.args": ["--do-smth"],
-    // "go.gotest.env": { "ENV2": "value" }, // will be merged with the ENV variable defined on the language level
+    ],
+    // "go.delve.args": ["--do-smth"],
+    // "go.delve.env": { "ENV2": "value" }, // will be merged with the ENV variable defined on the language level
     //
     // "go.ginkgo.runner": "command", // a runner for the Ginko test framework
     "go.ginkgo.executable": [
@@ -109,6 +110,14 @@
     ],
     // "go.ginkgo.args": ["--do-smth"],
     // "go.ginkgo.env": { "ENV2": "value" }, // will be merged with the ENV variable defined on the language level
+    //
+    // "go.gotest.runner": "command", // a runner for the Gotest test framework
+    "go.gotest.executable": [
+        "go",
+        "test"
+    ], // for richgo use ["richgo", "test"]
+    // "go.gotest.args": ["--do-smth"],
+    // "go.gotest.env": { "ENV2": "value" }, // will be merged with the ENV variable defined on the language level
     //
     // --- Java ---
     // "java.runner": "command", // a runner for all Java test frameworks

--- a/AnyTest.sublime-settings
+++ b/AnyTest.sublime-settings
@@ -98,7 +98,7 @@
     "go.gotest.executable": [
         "go",
         "test"
-    ],
+    ], // for richgo use ["richgo", "test"]
     // "go.gotest.args": ["--do-smth"],
     // "go.gotest.env": { "ENV2": "value" }, // will be merged with the ENV variable defined on the language level
     //

--- a/AnyTest.sublime-settings
+++ b/AnyTest.sublime-settings
@@ -7,7 +7,8 @@
             "exunit"
         ],
         "go": [
-            "gotest"
+            "ginkgo",
+            "gotest",
         ],
         "javascript": [
             "jest",
@@ -101,6 +102,13 @@
     ], // for richgo use ["richgo", "test"]
     // "go.gotest.args": ["--do-smth"],
     // "go.gotest.env": { "ENV2": "value" }, // will be merged with the ENV variable defined on the language level
+    //
+    // "go.ginkgo.runner": "command", // a runner for the Ginko test framework
+    "go.ginkgo.executable": [
+        "ginkgo"
+    ],
+    // "go.ginkgo.args": ["--do-smth"],
+    // "go.ginkgo.env": { "ENV2": "value" }, // will be merged with the ENV variable defined on the language level
     //
     // --- Java ---
     // "java.runner": "command", // a runner for all Java test frameworks

--- a/AnyTest.sublime-settings
+++ b/AnyTest.sublime-settings
@@ -88,6 +88,9 @@
     // "elixir.exunit.env": { "ENV2": "value" }, // will be merged with the ENV variable defined on the language level
     //
     // --- Go ---
+    // to force a Go test framework use:
+    // "go.test_framework": "gotest",
+    //
     // "go.runner": "command", // a runner for all Go test frameworks
     // "go.env": { "ENV1": "value" }, // will be merged with the ENV variable defined on the test framework level
     //

--- a/AnyTest.sublime-settings
+++ b/AnyTest.sublime-settings
@@ -6,6 +6,9 @@
             "espec",
             "exunit"
         ],
+        "go": [
+            "gotest"
+        ],
         "javascript": [
             "jest",
             "mocha",
@@ -83,6 +86,18 @@
     // "elixir.exunit.executable": ["mix", "do", "smth"],
     // "elixir.exunit.args": ["--do-smth"],
     // "elixir.exunit.env": { "ENV2": "value" }, // will be merged with the ENV variable defined on the language level
+    //
+    // --- Go ---
+    // "go.runner": "command", // a runner for all Go test frameworks
+    // "go.env": { "ENV1": "value" }, // will be merged with the ENV variable defined on the test framework level
+    //
+    // "go.gotest.runner": "command", // a runner for the Gotest test framework
+    "go.gotest.executable": [
+        "go",
+        "test"
+    ],
+    // "go.gotest.args": ["--do-smth"],
+    // "go.gotest.env": { "ENV2": "value" }, // will be merged with the ENV variable defined on the language level
     //
     // --- Java ---
     // "java.runner": "command", // a runner for all Java test frameworks

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Currently, the following test frameworks are supported (more test frameworks are
 |       Language | Test framework                                  | Identifiers                                                 |
 |---------------:|:------------------------------------------------|:------------------------------------------------------------|
 |     **Elixir** | ESpec, ExUnit                                   | `espec`, `exunit`                                           |
+|         **Go** | Gotest                                          | `gotest`                                                    |
 |       **Java** | JUnit (with Maven or Gradle)                    | `junit`                                                     |
 | **JavaScript** | Jest, Mocha, Vitest                             | `jest`, `mocha`, `vitest`                                   |
 |     **Python** | PyTest, PyUnit                                  | `pytest`, `pyunit`                                          |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Currently, the following test frameworks are supported (more test frameworks are
 |       Language | Test framework                                  | Identifiers                                                 |
 |---------------:|:------------------------------------------------|:------------------------------------------------------------|
 |     **Elixir** | ESpec, ExUnit                                   | `espec`, `exunit`                                           |
-|         **Go** | Gotest                                          | `gotest`                                                    |
+|         **Go** | Ginkgo, Gotest                                  | `gotest`, `ginkgo`                                          |
 |       **Java** | JUnit (with Maven or Gradle)                    | `junit`                                                     |
 | **JavaScript** | Jest, Mocha, Vitest                             | `jest`, `mocha`, `vitest`                                   |
 |     **Python** | PyTest, PyUnit                                  | `pytest`, `pyunit`                                          |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Currently, the following test frameworks are supported (more test frameworks are
 |       Language | Test framework                                  | Identifiers                                                 |
 |---------------:|:------------------------------------------------|:------------------------------------------------------------|
 |     **Elixir** | ESpec, ExUnit                                   | `espec`, `exunit`                                           |
-|         **Go** | Ginkgo, Gotest                                  | `gotest`, `ginkgo`                                          |
+|         **Go** | Delve, Ginkgo, Gotest                           | `delve`, `ginkgo`, `gotest`                                 |
 |       **Java** | JUnit (with Maven or Gradle)                    | `junit`                                                     |
 | **JavaScript** | Jest, Mocha, Vitest                             | `jest`, `mocha`, `vitest`                                   |
 |     **Python** | PyTest, PyUnit                                  | `pytest`, `pyunit`                                          |

--- a/plugin/context.py
+++ b/plugin/context.py
@@ -6,9 +6,51 @@ from operator import ge, le
 from . import settings
 from .mixins import WindowMixin
 from .root import Root
+from .utils import escape_regex as _escape_regex
 from .utils import match_patterns
 
-Nearest = namedtuple('Nearest', 'tests, namespaces, line, names')
+
+class Nearest(namedtuple('Nearest', 'tests, namespaces, line, names')):
+    __slots__ = ()
+
+    def join(
+        self,
+        sep,
+        namespace_sep=None,
+        test_sep=None,
+        start='',
+        namespace_start='',
+        test_end='',
+        end='',
+        escape_regex=False,
+    ):
+        if namespace_sep is None:
+            namespace_sep = sep
+
+        if test_sep is None:
+            test_sep = sep
+
+        has_tests_or_namespaces = bool(self.tests) or bool(self.namespaces)
+        joined = sep.join(
+            filter(
+                bool,
+                (namespace_sep.join(self.namespaces), test_sep.join(self.tests)),
+            ),
+        )
+
+        if escape_regex:
+            escape_function = escape_regex if callable(escape_regex) else _escape_regex
+            joined = escape_function(joined)
+
+        return ''.join(
+            (
+                start if has_tests_or_namespaces else '',
+                namespace_start if bool(self.namespaces) else '',
+                joined,
+                test_end if bool(self.tests) else '',
+                end if has_tests_or_namespaces else '',
+            )
+        )
 
 
 class Context(WindowMixin):

--- a/plugin/root.py
+++ b/plugin/root.py
@@ -66,6 +66,9 @@ class RelativePath:
     def contains(self, _):
         raise NotImplementedError()
 
+    def lines(self):
+        raise NotImplementedError()
+
     def dir(self):
         return Root(os.path.dirname(self.path))
 
@@ -80,6 +83,12 @@ class RelativePath:
             os.path.basename(self.relpath),
         )[0]
 
+    def is_in_root(self):
+        return self.dir().path == self.root.path
+
+    def dir_relpath(self):
+        raise NotImplementedError()
+
 
 class File(RelativePath):
     def exists(self):
@@ -88,6 +97,14 @@ class File(RelativePath):
     def contains(self, content):
         with open(self.path) as file:
             return content in file.read()
+
+    def lines(self):
+        with open(self.path) as file:
+            for line in file:
+                yield line.strip()
+
+    def dir_relpath(self):
+        return os.path.split(self.relpath)[0]
 
 
 class Glob:

--- a/plugin/root.py
+++ b/plugin/root.py
@@ -63,10 +63,10 @@ class RelativePath:
     def exists(self):
         return os.path.exists(self.path)
 
-    def contains(self, _):
+    def lines(self):
         raise NotImplementedError()
 
-    def lines(self):
+    def contains_line(self, _):
         raise NotImplementedError()
 
     def dir(self):
@@ -94,14 +94,17 @@ class File(RelativePath):
     def exists(self):
         return os.path.isfile(self.path)
 
-    def contains(self, content):
-        with open(self.path) as file:
-            return content in file.read()
-
     def lines(self):
         with open(self.path) as file:
             for line in file:
                 yield line.strip()
+
+    def contains_line(self, content):
+        for line in self.lines():
+            if content in line:
+                return True
+
+        return False
 
     def dir_relpath(self):
         return os.path.split(self.relpath)[0]

--- a/plugin/runners/__init__.py
+++ b/plugin/runners/__init__.py
@@ -73,6 +73,15 @@ class Runner(
             self.test_framework = test_framework
             self.scope = scope
 
+        def map_test_framework_options(self, **kwargs):
+            test_framework_options = self.test_framework.get_options()
+
+            return {
+                key: test_framework_options[tf_key]
+                for key, tf_key in kwargs.items()
+                if tf_key in test_framework_options
+            }
+
         def build_cmd(self):
             return ' '.join(self.test_framework.build_command(self.scope))
 

--- a/plugin/runners/command.py
+++ b/plugin/runners/command.py
@@ -27,15 +27,12 @@ class Runner(BaseRunner):
 
     class Builder(BaseRunner.Builder):
         def build_options(self):
-            options = {
-                'command_name': Runner.settings('name', type=str),
-                'encoding': 'utf-8',
-                'env': self.test_framework.settings(
-                    'env', default={}, fallback=False, type=dict, merge=True
-                ),
-            }
+            options = self.map_test_framework_options(file_regex='output_file_regex')
 
-            if self.test_framework.output_file_regex is not None:
-                options['file_regex'] = self.test_framework.output_file_regex
+            options['command_name'] = Runner.settings('name', type=str)
+            options['encoding'] = 'utf-8'
+            options['env'] = self.test_framework.settings(
+                'env', default={}, fallback=False, type=dict, merge=True
+            )
 
             return options

--- a/plugin/test_frameworks/__init__.py
+++ b/plugin/test_frameworks/__init__.py
@@ -142,7 +142,8 @@ class TestFramework(metaclass=ABCMeta):
         pass
 
     def build_command(self, scope):
-        if scope in (self.SCOPE_SUITE, self.SCOPE_FILE, self.SCOPE_LINE):
+        method_name = 'build_{}_position_args'.format(scope)
+        if hasattr(self, method_name):
             position_args = getattr(self, 'build_{}_position_args'.format(scope))
 
             return self.executable() + self.args() + position_args()

--- a/plugin/test_frameworks/__init__.py
+++ b/plugin/test_frameworks/__init__.py
@@ -54,7 +54,6 @@ class TestFramework(metaclass=ABCMeta):
 
     test_patterns = None
     namespace_patterns = []
-    output_file_regex = None
 
     def __init__(self, context):
         self.context = context
@@ -149,3 +148,6 @@ class TestFramework(metaclass=ABCMeta):
             return self.executable() + self.args() + position_args()
         else:
             raise errors.Error('Invalid scope')
+
+    def get_options(self):
+        return {}

--- a/plugin/test_frameworks/go/__init__.py
+++ b/plugin/test_frameworks/go/__init__.py
@@ -3,12 +3,4 @@ from .. import TestFramework as BaseTestFramework
 
 class TestFramework(BaseTestFramework):
     language = 'go'  # type: str
-    test_patterns = (
-        r'^\s*func ((Test|Example).*)\(',
-        r'^\s*func \(.*\) ((Test).*)\(',
-        r'^\s*t\.Run\("(.*)"',
-    )
-    namespace_patterns = (
-        r'^\s*func ((Test).*)\(',
-        r'^\s*t\.Run\("(.*)"',
-    )
+    pattern = r'[^_].*_test\.go$'  # type: str

--- a/plugin/test_frameworks/go/__init__.py
+++ b/plugin/test_frameworks/go/__init__.py
@@ -4,3 +4,8 @@ from .. import TestFramework as BaseTestFramework
 class TestFramework(BaseTestFramework):
     language = 'go'  # type: str
     pattern = r'[^_].*_test\.go$'  # type: str
+
+    def get_package(self):
+        return (
+            '.' if self.context.file.is_in_root() else self.context.file.dir_relpath()
+        )

--- a/plugin/test_frameworks/go/__init__.py
+++ b/plugin/test_frameworks/go/__init__.py
@@ -1,0 +1,14 @@
+from .. import TestFramework as BaseTestFramework
+
+
+class TestFramework(BaseTestFramework):
+    language = 'go'  # type: str
+    test_patterns = (
+        r'^\s*func ((Test|Example).*)\(',
+        r'^\s*func \(.*\) ((Test).*)\(',
+        r'^\s*t\.Run\("(.*)"',
+    )
+    namespace_patterns = (
+        r'^\s*func ((Test).*)\(',
+        r'^\s*t\.Run\("(.*)"',
+    )

--- a/plugin/test_frameworks/go/delve.py
+++ b/plugin/test_frameworks/go/delve.py
@@ -1,0 +1,35 @@
+import shlex
+
+from .. import go
+from ..mixins import IsConfigurableMixin
+from .ginkgo import TestFramework as Ginkgo
+from .gotest import TestFramework as Gotest
+
+
+class TestFramework(IsConfigurableMixin, go.TestFramework):
+    framework = 'delve'  # type: str
+
+    def build_suite_position_args(self):
+        return ['./...']
+
+    def build_file_position_args(self):
+        if self.context.file.is_in_root():
+            return []
+
+        return ['./{}/...'.format(self.context.file.dir_relpath())]
+
+    def build_line_position_args(self):
+        is_ginkgo = Ginkgo.imports_ginkgo(self.context.file)
+        test_framework = Ginkgo(self.context) if is_ginkgo else Gotest(self.context)
+        nearest = test_framework.find_nearest()
+        name = ' '.join(nearest.tests)
+
+        if bool(name):
+            args = ['./{}'.format(self.get_package())]
+
+            if is_ginkgo:
+                return args + ['--', '-ginkgo.focus={}'.format(shlex.quote(name))]
+            else:
+                return args + ['--', '-test.run', shlex.quote('{}$'.format(name))]
+        else:
+            return self.build_file_position_args()

--- a/plugin/test_frameworks/go/ginkgo.py
+++ b/plugin/test_frameworks/go/ginkgo.py
@@ -1,5 +1,6 @@
 import shlex
 
+from ...cache import cache
 from .. import go
 from ..mixins import IsConfigurableMixin
 
@@ -17,14 +18,16 @@ class TestFramework(IsConfigurableMixin, go.TestFramework):
     namespace_patterns = ()
 
     @classmethod
-    def is_configurable_fallback(cls, file):
+    @cache
+    def imports_ginkgo(cls, file):
         return file.contains_line('github.com/onsi/ginkgo')
 
-    def build_suite_position_args(self):
-        if self.context.file.is_in_root():
-            return ['./.']
+    @classmethod
+    def is_configurable_fallback(cls, file):
+        return cls.imports_ginkgo(file)
 
-        return ['./{}'.format(self.context.file.dir_relpath())]
+    def build_suite_position_args(self):
+        return ['./{}'.format(self.get_package())]
 
     def build_file_position_args(self):
         return [

--- a/plugin/test_frameworks/go/ginkgo.py
+++ b/plugin/test_frameworks/go/ginkgo.py
@@ -1,0 +1,42 @@
+import shlex
+
+from .. import go
+from ..mixins import IsConfigurableMixin
+
+
+class TestFramework(IsConfigurableMixin, go.TestFramework):
+    NEAREST_SEPARATOR = '/'
+
+    framework = 'ginkgo'  # type: str
+    test_patterns = (
+        r'^\s*It\("(.*)",',
+        r'^\s*When\("(.*)",',
+        r'^\s*Context\("(.*)",',
+        r'.*Describe\("(.*)",',
+    )
+    namespace_patterns = ()
+
+    @classmethod
+    def is_configurable_fallback(cls, file):
+        return file.contains_line('github.com/onsi/ginkgo')
+
+    def build_suite_position_args(self):
+        if self.context.file.is_in_root():
+            return ['./.']
+
+        return ['./{}'.format(self.context.file.dir_relpath())]
+
+    def build_file_position_args(self):
+        return [
+            '--focus-file={}'.format(self.context.file.relpath)
+        ] + self.build_suite_position_args()
+
+    def build_line_position_args(self):
+        nearest = self.find_nearest()
+
+        if bool(nearest.tests):
+            return [
+                '--focus={}'.format(shlex.quote(nearest.tests[0]))
+            ] + self.build_suite_position_args()
+        else:
+            return self.build_file_position_args()

--- a/plugin/test_frameworks/go/gotest.py
+++ b/plugin/test_frameworks/go/gotest.py
@@ -1,32 +1,9 @@
 import os.path
 import re
 
+from ...utils import escape_regex
 from .. import go
 from ..mixins import IsConfigurableMixin
-
-REGEXP_ESCAPE_TRANSLATION_TABLE = str.maketrans(
-    {
-        '?': r'\\\?',
-        '+': r'\\\+',
-        '*': r'\\\*',
-        '\\': r'\\\\',
-        '^': r'\\\^',
-        '$': r'\\\\\$',
-        '.': r'\\\.',
-        '|': r'\\\\\|',
-        '{': r'\\\{',
-        '}': r'\\\}',
-        '[': r'\\\[',
-        ']': r'\\\]',
-        '(': r'\\\\\(',
-        ')': r'\\\\\)',
-    }
-)
-
-
-# TODO: This escape function doesn't work correctly with |()$^ symbols when the runner is `command`
-def escape_regex(string):
-    return string.translate(REGEXP_ESCAPE_TRANSLATION_TABLE)
 
 
 class TestFramework(IsConfigurableMixin, go.TestFramework):
@@ -47,10 +24,12 @@ class TestFramework(IsConfigurableMixin, go.TestFramework):
     def build_line_position_args(self):
         args = self.build_file_position_args()
         name = re.sub(
-            r'\s+',
+            r'\s',
             '_',
             self.find_nearest().join(
-                self.NEAREST_SEPARATOR, end=r'\$', escape_regex=escape_regex
+                self.NEAREST_SEPARATOR,
+                end='$',
+                escape_regex=lambda x: escape_regex(escape_regex(x)),
             ),
         )
 

--- a/plugin/test_frameworks/go/gotest.py
+++ b/plugin/test_frameworks/go/gotest.py
@@ -1,0 +1,60 @@
+import os.path
+import re
+
+from .. import go
+from ..mixins import IsConfigurableMixin
+
+REGEXP_ESCAPE_TRANSLATION_TABLE = str.maketrans(
+    {
+        '?': r'\\\?',
+        '+': r'\\\+',
+        '*': r'\\\*',
+        '\\': r'\\\\',
+        '^': r'\\\^',
+        '$': r'\\\\\$',
+        '.': r'\\\.',
+        '|': r'\\\\\|',
+        '{': r'\\\{',
+        '}': r'\\\}',
+        '[': r'\\\[',
+        ']': r'\\\]',
+        '(': r'\\\\\(',
+        ')': r'\\\\\)',
+    }
+)
+
+
+# TODO: This escape function doesn't work correctly with |()$^ symbols when the runner is `command`
+def escape_regex(string):
+    return string.translate(REGEXP_ESCAPE_TRANSLATION_TABLE)
+
+
+class TestFramework(IsConfigurableMixin, go.TestFramework):
+    NEAREST_SEPARATOR = '/'
+
+    framework = 'gotest'  # type: str
+    pattern = r'[^_].*_test\.go$'  # type: str
+
+    def build_suite_position_args(self):
+        return ['./...']
+
+    def build_file_position_args(self):
+        if self.context.file.dir().path == self.context.root.path:
+            return []
+
+        return ['./{}/...'.format(os.path.split(self.context.file.relpath)[0])]
+
+    def build_line_position_args(self):
+        args = self.build_file_position_args()
+        name = re.sub(
+            r'\s+',
+            '_',
+            self.find_nearest().join(
+                self.NEAREST_SEPARATOR, end=r'\$', escape_regex=escape_regex
+            ),
+        )
+
+        if bool(name):
+            return ['-run', name] + (args if bool(args) else ['./.'])
+        else:
+            return args

--- a/plugin/test_frameworks/go/gotest.py
+++ b/plugin/test_frameworks/go/gotest.py
@@ -9,7 +9,15 @@ class TestFramework(IsConfigurableMixin, go.TestFramework):
     NEAREST_SEPARATOR = '/'
 
     framework = 'gotest'  # type: str
-    pattern = r'[^_].*_test\.go$'  # type: str
+    test_patterns = (
+        r'^\s*func ((Test|Example).*)\(',
+        r'^\s*func \(.*\) ((Test).*)\(',
+        r'^\s*t\.Run\("(.*)"',
+    )
+    namespace_patterns = (
+        r'^\s*func ((Test).*)\(',
+        r'^\s*t\.Run\("(.*)"',
+    )
 
     def build_suite_position_args(self):
         return ['./...']

--- a/plugin/test_frameworks/go/gotest.py
+++ b/plugin/test_frameworks/go/gotest.py
@@ -1,4 +1,3 @@
-import os.path
 import re
 
 from ...utils import escape_regex

--- a/plugin/test_frameworks/java/build_tool.py
+++ b/plugin/test_frameworks/java/build_tool.py
@@ -19,6 +19,7 @@ def find(file):
 
 class Base(metaclass=ABCMeta):
     MAX_DEPTH = 20
+    NAMESPACE_SEPARATOR = '$'
 
     @property
     @abstractmethod
@@ -69,6 +70,8 @@ class Maven(Base):
         (r'\/[^\/]+$', ''),
         (r'/', '.'),
     )
+    NEAREST_SEPARATOR = '$'
+    SECTION_SEPARATOR = '#'
 
     executable = 'mvn'  # type: str
     config_filenames = ('pom.xml',)  # type: tuple
@@ -89,9 +92,9 @@ class Maven(Base):
     def build_line_position_args(self, nearest):
         name = ''.join(
             (
-                utils.escape_regex('$'.join(nearest.namespaces)),
-                '#' if bool(nearest.namespaces) else '',
-                utils.escape_regex('$'.join(nearest.tests)),
+                utils.escape_regex(self.NAMESPACE_SEPARATOR.join(nearest.namespaces)),
+                self.SECTION_SEPARATOR if bool(nearest.namespaces) else '',
+                utils.escape_regex(self.NEAREST_SEPARATOR.join(nearest.tests)),
             )
         )
 
@@ -100,6 +103,8 @@ class Maven(Base):
 
 
 class Gradle(Base):
+    NEAREST_SEPARATOR = '.'
+
     executable = 'gradle'  # type: str
     config_filenames = (
         'build.gradle',
@@ -117,9 +122,9 @@ class Gradle(Base):
     def build_line_position_args(self, nearest):
         name = ''.join(
             (
-                utils.escape_regex('$'.join(nearest.namespaces)),
-                '.' if bool(nearest.namespaces) else '',
-                utils.escape_regex('.'.join(nearest.tests)),
+                utils.escape_regex(self.NAMESPACE_SEPARATOR.join(nearest.namespaces)),
+                self.NEAREST_SEPARATOR if bool(nearest.namespaces) else '',
+                utils.escape_regex(self.NEAREST_SEPARATOR.join(nearest.tests)),
             )
         )
 

--- a/plugin/test_frameworks/java/build_tool.py
+++ b/plugin/test_frameworks/java/build_tool.py
@@ -1,6 +1,4 @@
-import re
 from abc import ABCMeta, abstractmethod
-from functools import reduce
 
 from ... import utils
 from ...cache import cache

--- a/plugin/test_frameworks/java/build_tool.py
+++ b/plugin/test_frameworks/java/build_tool.py
@@ -77,11 +77,7 @@ class Maven(Base):
     config_filenames = ('pom.xml',)  # type: tuple
 
     def get_package(self):
-        return reduce(
-            lambda value, args: re.sub(args[0], args[1], value),
-            self.PACKAGE_REPLACEMENTS,
-            self.file.relpath,
-        )
+        return utils.replace(self.file.relpath, *self.PACKAGE_REPLACEMENTS)
 
     def build_module_args(self, module):
         return ['-pl', module]

--- a/plugin/test_frameworks/javascript/jest.py
+++ b/plugin/test_frameworks/javascript/jest.py
@@ -1,3 +1,5 @@
+import shlex
+
 from ... import utils
 from .. import javascript
 from ..mixins import IsConfigurableMixin
@@ -32,7 +34,7 @@ class TestFramework(IsConfigurableMixin, javascript.TestFramework):
         )
 
         if bool(name):
-            args = ['-t', utils.escape_shell(name)] + args
+            args = ['-t', shlex.quote(name)] + args
 
         return args
 

--- a/plugin/test_frameworks/javascript/mocha.py
+++ b/plugin/test_frameworks/javascript/mocha.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shlex
 
 from ... import utils
 from .. import javascript
@@ -60,6 +61,6 @@ class TestFramework(IsConfigurableMixin, javascript.TestFramework):
         )
 
         if bool(name):
-            args += ['--grep', utils.escape_shell(name)]
+            args += ['--grep', shlex.quote(name)]
 
         return args

--- a/plugin/test_frameworks/javascript/vitest.py
+++ b/plugin/test_frameworks/javascript/vitest.py
@@ -1,3 +1,5 @@
+import shlex
+
 from ... import utils
 from .. import javascript
 from ..mixins import IsConfigurableMixin
@@ -24,6 +26,6 @@ class TestFramework(IsConfigurableMixin, javascript.TestFramework):
         name = utils.escape_regex(' '.join(nearest.namespaces + nearest.tests))
 
         if bool(name):
-            args = ['-t', utils.escape_shell(name)] + args
+            args = ['-t', shlex.quote(name)] + args
 
         return args

--- a/plugin/test_frameworks/ruby/minitest.py
+++ b/plugin/test_frameworks/ruby/minitest.py
@@ -40,7 +40,7 @@ class TestFramework(ruby.TestFramework):
     def use_rake(self):
         return (
             self.rakefile().exists()
-            and self.rakefile().contains('Rake::TestTask')
+            and self.rakefile().contains_line('Rake::TestTask')
             or self.file('bin', 'rails').exists()
         )
 

--- a/plugin/test_frameworks/ruby/minitest.py
+++ b/plugin/test_frameworks/ruby/minitest.py
@@ -110,9 +110,9 @@ class TestFramework(ruby.TestFramework):
         return (
             [
                 'find',
-                utils.escape_shell(self.test_folder(), quote=False),
+                self.test_folder(),
                 '-name',
-                utils.escape_shell(self.test_file_pattern(), quote=False),
+                self.test_file_pattern(),
                 '-exec',
             ]
             + command

--- a/plugin/test_frameworks/rust/cargotest.py
+++ b/plugin/test_frameworks/rust/cargotest.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shlex
 
 from ... import utils
 from .. import rust
@@ -36,7 +37,7 @@ class TestFramework(rust.TestFramework):
             return args
 
         namespace = self.NEAREST_SEPARATOR.join(modules[1:] + [''])
-        return args + [utils.escape_shell(namespace)]
+        return args + [shlex.quote(namespace)]
 
     def build_line_position_args(self):
         file_args = self.build_file_position_args()

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -1,5 +1,4 @@
 import re
-import shlex
 from distutils import spawn
 from functools import reduce
 

--- a/plugin/utils.py
+++ b/plugin/utils.py
@@ -1,6 +1,7 @@
 import re
 import shlex
 from distutils import spawn
+from functools import reduce
 
 REGEXP_ESCAPE_TRANSLATION_TABLE = str.maketrans(
     {
@@ -20,22 +21,13 @@ REGEXP_ESCAPE_TRANSLATION_TABLE = str.maketrans(
         ')': r'\)',
     }
 )
-SHELL_ESCAPE_TRANSLATION_TABLE = str.maketrans(
-    {
-        '$': r'\$',  # to avoid issues with the $ symbol in terminus
-    }
-)
 
 
 def escape_regex(string):
+    """
+    Switch to re.escape once upgrade to Python 3.8 as it doesn't escape the / symbol
+    """
     return string.translate(REGEXP_ESCAPE_TRANSLATION_TABLE)
-
-
-def escape_shell(string, quote=True):
-    if quote:
-        string = shlex.quote(string)
-
-    return string.translate(SHELL_ESCAPE_TRANSLATION_TABLE)
 
 
 def escape(string, symbols):
@@ -65,3 +57,11 @@ def match_patterns(string, patterns):
             return match.group(1), name
 
     return None, None
+
+
+def replace(string, *replacements):
+    return reduce(
+        lambda value, args: re.sub(args[0], args[1], value),
+        replacements,
+        string,
+    )

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -25,6 +25,12 @@
                                 "exunit"
                             ]
                         },
+                        "GoFrameworks": {
+                            "type": "string",
+                            "enum": [
+                                "gotest"
+                            ]
+                        },
                         "JavascriptFrameworks": {
                             "type": "string",
                             "enum": [
@@ -102,6 +108,19 @@
                                                     "type": "array",
                                                     "items": {
                                                         "$ref": "sublime://settings/AnyTest#/definitions/ElixirFrameworks"
+                                                    }
+                                                }
+                                            ]
+                                        },
+                                        "go": {
+                                            "anyOf": [
+                                                {
+                                                    "$ref": "sublime://settings/AnyTest#/definitions/GoFrameworks"
+                                                },
+                                                {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "$ref": "sublime://settings/AnyTest#/definitions/GoFrameworks"
                                                     }
                                                 }
                                             ]
@@ -314,6 +333,37 @@
                                     "type": "object",
                                     "default": {},
                                     "description": "ExUnit specific ENV variables (will be merged with the ENV variables defined on the language level)"
+                                },
+                                "go.runner": {
+                                    "$ref": "sublime://settings/AnyTest#/definitions/Runner",
+                                    "description": "A runner to run Go tests with"
+                                },
+                                "go.env": {
+                                    "type": "object",
+                                    "default": {},
+                                    "description": "Go specific ENV variables (will be merged with the ENV variables defined on the test framework level)"
+                                },
+                                "go.gotest.runner": {
+                                    "$ref": "sublime://settings/AnyTest#/definitions/Runner",
+                                    "description": "A runner to run Gotest tests with"
+                                },
+                                "go.gotest.executable": {
+                                    "type": "array",
+                                    "default": [
+                                        "go",
+                                        "test"
+                                    ],
+                                    "description": "Gotest test framework executable (e.g. [\"go\", \"my_test\"])"
+                                },
+                                "go.gotest.args": {
+                                    "type": "array",
+                                    "default": [],
+                                    "description": "Gotest cli args (e.g. [\"--do-smth\"])"
+                                },
+                                "go.gotest.env": {
+                                    "type": "object",
+                                    "default": {},
+                                    "description": "Gotest specific ENV variables (will be merged with the ENV variables defined on the language level)"
                                 },
                                 "java.env": {
                                     "type": "object",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -28,6 +28,7 @@
                         "GoFrameworks": {
                             "type": "string",
                             "enum": [
+                                "ginkgo",
                                 "gotest"
                             ]
                         },
@@ -368,10 +369,31 @@
                                     "default": {},
                                     "description": "Gotest specific ENV variables (will be merged with the ENV variables defined on the language level)"
                                 },
+                                "go.ginko.runner": {
+                                    "$ref": "sublime://settings/AnyTest#/definitions/Runner",
+                                    "description": "A runner to run Ginkgo tests with"
+                                },
+                                "go.ginko.executable": {
+                                    "type": "array",
+                                    "default": [
+                                        "ginkgo"
+                                    ],
+                                    "description": "Ginkgo test framework executable (e.g. [\"my_ginkgo\"])"
+                                },
+                                "go.ginko.args": {
+                                    "type": "array",
+                                    "default": [],
+                                    "description": "Ginkgo cli args (e.g. [\"--do-smth\"])"
+                                },
+                                "go.ginko.env": {
+                                    "type": "object",
+                                    "default": {},
+                                    "description": "Ginkgo specific ENV variables (will be merged with the ENV variables defined on the language level)"
+                                },
                                 "java.env": {
                                     "type": "object",
                                     "default": {},
-                                    "description": "Swift specific ENV variables (will be merged with the ENV variables defined on the test framework level)"
+                                    "description": "Java specific ENV variables (will be merged with the ENV variables defined on the test framework level)"
                                 },
                                 "java.junit.runner": {
                                     "$ref": "sublime://settings/AnyTest#/definitions/Runner",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -334,6 +334,9 @@
                                     "default": {},
                                     "description": "ExUnit specific ENV variables (will be merged with the ENV variables defined on the language level)"
                                 },
+                                "go.test_framework": {
+                                    "$ref": "sublime://settings/AnyTest#/definitions/GoFrameworks"
+                                },
                                 "go.runner": {
                                     "$ref": "sublime://settings/AnyTest#/definitions/Runner",
                                     "description": "A runner to run Go tests with"

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -28,6 +28,7 @@
                         "GoFrameworks": {
                             "type": "string",
                             "enum": [
+                                "delve",
                                 "ginkgo",
                                 "gotest"
                             ]
@@ -347,27 +348,27 @@
                                     "default": {},
                                     "description": "Go specific ENV variables (will be merged with the ENV variables defined on the test framework level)"
                                 },
-                                "go.gotest.runner": {
+                                "go.delve.runner": {
                                     "$ref": "sublime://settings/AnyTest#/definitions/Runner",
-                                    "description": "A runner to run Gotest tests with"
+                                    "description": "A runner to run Delve tests with"
                                 },
-                                "go.gotest.executable": {
+                                "go.delve.executable": {
                                     "type": "array",
                                     "default": [
-                                        "go",
+                                        "dlv",
                                         "test"
                                     ],
-                                    "description": "Gotest test framework executable (e.g. [\"go\", \"my_test\"])"
+                                    "description": "Delve test framework executable (e.g. [\"dlv\", \"my_test\"])"
                                 },
-                                "go.gotest.args": {
+                                "go.delve.args": {
                                     "type": "array",
                                     "default": [],
-                                    "description": "Gotest cli args (e.g. [\"--do-smth\"])"
+                                    "description": "Delve cli args (e.g. [\"--do-smth\"])"
                                 },
-                                "go.gotest.env": {
+                                "go.delve.env": {
                                     "type": "object",
                                     "default": {},
-                                    "description": "Gotest specific ENV variables (will be merged with the ENV variables defined on the language level)"
+                                    "description": "Delve specific ENV variables (will be merged with the ENV variables defined on the language level)"
                                 },
                                 "go.ginko.runner": {
                                     "$ref": "sublime://settings/AnyTest#/definitions/Runner",
@@ -389,6 +390,28 @@
                                     "type": "object",
                                     "default": {},
                                     "description": "Ginkgo specific ENV variables (will be merged with the ENV variables defined on the language level)"
+                                },
+                                "go.gotest.runner": {
+                                    "$ref": "sublime://settings/AnyTest#/definitions/Runner",
+                                    "description": "A runner to run Gotest tests with"
+                                },
+                                "go.gotest.executable": {
+                                    "type": "array",
+                                    "default": [
+                                        "go",
+                                        "test"
+                                    ],
+                                    "description": "Gotest test framework executable (e.g. [\"go\", \"my_test\"])"
+                                },
+                                "go.gotest.args": {
+                                    "type": "array",
+                                    "default": [],
+                                    "description": "Gotest cli args (e.g. [\"--do-smth\"])"
+                                },
+                                "go.gotest.env": {
+                                    "type": "object",
+                                    "default": {},
+                                    "description": "Gotest specific ENV variables (will be merged with the ENV variables defined on the language level)"
                                 },
                                 "java.env": {
                                     "type": "object",

--- a/tests/fixtures/delve/ginkgo_test.go
+++ b/tests/fixtures/delve/ginkgo_test.go
@@ -1,0 +1,36 @@
+package mypackage
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("posts API", func() {
+
+	Context("when the request is authenticated", func() {
+
+		It("should return list of posts owned by the user", func() {
+
+		})
+
+		It("should paginate the result", func() {
+
+		})
+
+	})
+
+	Context("when the request is not authenticated", func() {
+
+		It("should deny access", func() {
+
+		})
+	})
+
+	When("user is not logged in", func() {
+
+		It("should deny access", func() {
+
+		})
+	})
+
+})

--- a/tests/fixtures/delve/mypackage/normal_test.go
+++ b/tests/fixtures/delve/mypackage/normal_test.go
@@ -1,0 +1,18 @@
+package mypackage
+
+import "testing"
+
+func TestNumbers(*testing.T) {
+	// assertions
+}
+
+func Testテスト(*testing.T) {
+	// assertions
+}
+
+func ExampleSomething() {
+	// Output:
+}
+
+func Something() {
+}

--- a/tests/fixtures/delve/normal_test.go
+++ b/tests/fixtures/delve/normal_test.go
@@ -1,0 +1,18 @@
+package mypackage
+
+import "testing"
+
+func TestNumbers(*testing.T) {
+	// assertions
+}
+
+func Testテスト(*testing.T) {
+	// assertions
+}
+
+func ExampleSomething() {
+	// Output:
+}
+
+func Something() {
+}

--- a/tests/fixtures/ginkgo/mypackage/normal_test.go
+++ b/tests/fixtures/ginkgo/mypackage/normal_test.go
@@ -1,0 +1,29 @@
+package mypackage_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("posts API", func() {
+
+	Context("when the request is authenticated", func() {
+
+		It("should return list of posts owned by the user", func() {
+
+		})
+
+		It("should paginate the result", func() {
+
+		})
+
+	})
+
+	Context("when the request is not authenticated", func() {
+
+		It("should deny access", func() {
+
+		})
+	})
+
+})

--- a/tests/fixtures/ginkgo/normal_test.go
+++ b/tests/fixtures/ginkgo/normal_test.go
@@ -1,0 +1,36 @@
+package mypackage_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("posts API", func() {
+
+	Context("when the request is authenticated", func() {
+
+		It("should return list of posts owned by the user", func() {
+
+		})
+
+		It("should paginate the result", func() {
+
+		})
+
+	})
+
+	Context("when the request is not authenticated", func() {
+
+		It("should deny access", func() {
+
+		})
+	})
+
+	When("user is not logged in", func() {
+
+		It("should deny access", func() {
+			Expect(true).To(BeTrue())
+		})
+	})
+
+})

--- a/tests/fixtures/gotest/build_tags_test.go
+++ b/tests/fixtures/gotest/build_tags_test.go
@@ -1,0 +1,15 @@
+// some comments are allowed before tags
+
+//go:build foo && hello && world && !bar && (red || black)
+// +build foo
+// +build hello,world
+// +build !bar
+// +build red black
+
+package mypackage
+
+import "testing"
+
+func TestNumbers(*testing.T) {
+	// assertions
+}

--- a/tests/fixtures/gotest/go.mod
+++ b/tests/fixtures/gotest/go.mod
@@ -1,0 +1,3 @@
+module example.com/m
+
+go 1.19

--- a/tests/fixtures/gotest/mypackage/normal_test.go
+++ b/tests/fixtures/gotest/mypackage/normal_test.go
@@ -1,0 +1,24 @@
+package mypackage
+
+import "testing"
+
+func TestNumbers(*testing.T) {
+	// assertions
+}
+
+func Testテスト(*testing.T) {
+	// assertions
+}
+
+func ExampleSomething() {
+	// Output:
+}
+
+func Something() {
+}
+
+type TestSomeTestifySuite struct{}
+
+func (suite *TestSomeTestifySuite) TestSomething() {
+	// assertions
+}

--- a/tests/fixtures/gotest/normal_test.go
+++ b/tests/fixtures/gotest/normal_test.go
@@ -1,0 +1,38 @@
+package mypackage
+
+import "testing"
+
+func TestNumbers(t *testing.T) {
+	// assertions
+
+	t.Run("adding two numbers", func(t *testing.T) {
+		// sub test assertions
+	})
+
+	t.Run("[].*+?|$^()", func(t *testing.T) {
+		// sub test assertions
+	})
+
+	t.Run("this is", func(t *testing.T) {
+		t.Run("nested", func(t *testing.T) {
+			// nested test assertions
+		})
+	})
+}
+
+func Testテスト(*testing.T) {
+	// assertions
+}
+
+func ExampleSomething() {
+	// Output:
+}
+
+func Something() {
+}
+
+type TestSomeTestifySuite struct{}
+
+func (suite *TestSomeTestifySuite) TestSomethingInASuite() {
+	// assertions
+}

--- a/tests/runners/test_terminus.py
+++ b/tests/runners/test_terminus.py
@@ -52,7 +52,10 @@ class TerminusBuilderTestCase(unittest.TestCase):
     def test_build_cmd(self):
         self.assertBuiltCmd(
             r'go test -run TestNumbers/\\\[\\\]\\\.\\\*\\\+\\\?\\\|\\\$\\\^\\\(\\\)$ ./.',
-            r'go test -run TestNumbers/\\\[\\\]\\\.\\\*\\\+\\\?\\\\\|\\\\\$\\\\\^\\\\\(\\\\\)\$ ./.',
+            (
+                r'go test -run TestNumbers'
+                r'/\\\[\\\]\\\.\\\*\\\+\\\?\\\\\|\\\\\$\\\\\^\\\\\(\\\\\)\$ ./.'
+            ),
         )
         self.assertBuiltCmd(
             r'do smth\$',

--- a/tests/runners/test_terminus.py
+++ b/tests/runners/test_terminus.py
@@ -1,3 +1,5 @@
+import unittest
+
 from AnyTest.plugin.runners.terminus import Runner as TerminusRunner
 from AnyTest.tests import SublimeWindowTestCase
 
@@ -32,3 +34,27 @@ class TerminusRunnerTestCase(SublimeWindowTestCase):
 
         self.assertEqual(runner.get_command_name(), TerminusRunner.COMMAND_NAME)
         self.assertEqual(runner.options, {})
+
+
+class FakeTestFramework:
+    def __init__(self, command):
+        self.command = command
+
+    def build_command(self, _):
+        return [self.command]
+
+
+class TerminusBuilderTestCase(unittest.TestCase):
+    def assertBuiltCmd(self, command, expected):
+        builder = TerminusRunner.Builder(FakeTestFramework(command), 'scope')
+        self.assertEqual(builder.build_cmd(), expected)
+
+    def test_build_cmd(self):
+        self.assertBuiltCmd(
+            r'go test -run TestNumbers/\\\[\\\]\\\.\\\*\\\+\\\?\\\|\\\$\\\^\\\(\\\)$ ./.',
+            r'go test -run TestNumbers/\\\[\\\]\\\.\\\*\\\+\\\?\\\\\|\\\\\$\\\\\^\\\\\(\\\\\)\$ ./.',
+        )
+        self.assertBuiltCmd(
+            r'do smth\$',
+            r'do smth\$',
+        )

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,7 +1,96 @@
+import unittest
 from unittest.mock import patch
 
-from AnyTest.plugin.context import Context
+from AnyTest.plugin.context import Context, Nearest
 from AnyTest.tests import SublimeViewTestCase
+
+
+class NearestTestCase(unittest.TestCase):
+    def setUp(self):
+        self.nearest = Nearest(
+            ('test1', 'test2'), ('namespace1', 'namespace2'), 0, None
+        )
+        self.nearest_empty = Nearest((), (), 0, None)
+        self.nearest_no_namespaces = Nearest(('test1', 'test2'), (), 0, None)
+        self.nearest_no_tests = Nearest((), ('namespace1', 'namespace2'), 0, None)
+
+    def test_join(self):
+        self.assertEqual(self.nearest.join('/'), 'namespace1/namespace2/test1/test2')
+        self.assertEqual(self.nearest_empty.join('/'), '')
+        self.assertEqual(self.nearest_no_namespaces.join('/'), 'test1/test2')
+        self.assertEqual(self.nearest_no_tests.join('/'), 'namespace1/namespace2')
+
+    def test_join_escape_regex_symbols(self):
+        self.assertEqual(
+            self.nearest.join('.', escape_regex=True),
+            'namespace1\\.namespace2\\.test1\\.test2',
+        )
+        self.assertEqual(
+            self.nearest.join('.', escape_regex=lambda x: x.upper()),
+            'NAMESPACE1.NAMESPACE2.TEST1.TEST2',
+        )
+
+    def test_join_sep(self):
+        self.assertEqual(
+            self.nearest.join('/', namespace_sep='_'),
+            'namespace1_namespace2/test1/test2',
+        )
+        self.assertEqual(
+            self.nearest.join('/', test_sep='_'),
+            'namespace1/namespace2/test1_test2',
+        )
+        self.assertEqual(
+            self.nearest.join('/', namespace_sep='-', test_sep='_'),
+            'namespace1-namespace2/test1_test2',
+        )
+
+    def test_join_start(self):
+        self.assertEqual(
+            self.nearest.join('/', namespace_sep='_', test_sep='-', start='^'),
+            '^namespace1_namespace2/test1-test2',
+        )
+        self.assertEqual(
+            self.nearest_no_namespaces.join(
+                '/', namespace_sep='_', test_sep='-', start='^'
+            ),
+            '^test1-test2',
+        )
+
+    def test_join_namespace_start(self):
+        self.assertEqual(
+            self.nearest.join(
+                '/', namespace_sep='_', test_sep='-', namespace_start='^'
+            ),
+            '^namespace1_namespace2/test1-test2',
+        )
+        self.assertEqual(
+            self.nearest_no_namespaces.join(
+                '/', namespace_sep='_', test_sep='-', namespace_start='^'
+            ),
+            'test1-test2',
+        )
+
+    def test_join_end(self):
+        self.assertEqual(
+            self.nearest.join('/', namespace_sep='_', test_sep='-', end='$'),
+            'namespace1_namespace2/test1-test2$',
+        )
+        self.assertEqual(
+            self.nearest_no_tests.join('/', namespace_sep='_', test_sep='-', end='$'),
+            'namespace1_namespace2$',
+        )
+
+    def test_join_test_end(self):
+        self.assertEqual(
+            self.nearest.join('/', namespace_sep='_', test_sep='-', test_end='$'),
+            'namespace1_namespace2/test1-test2$',
+        )
+        self.assertEqual(
+            self.nearest_no_tests.join(
+                '/', namespace_sep='_', test_sep='-', test_end='$'
+            ),
+            'namespace1_namespace2',
+        )
 
 
 class ContextTestCase(SublimeViewTestCase):

--- a/tests/test_frameworks/go/test_delve.py
+++ b/tests/test_frameworks/go/test_delve.py
@@ -1,0 +1,50 @@
+from AnyTest.tests import SublimeProjectTestCase
+
+
+class GotestTestCase(SublimeProjectTestCase):
+    folder = 'delve'
+    settings = {'go.test_framework': 'delve'}
+
+    def test_line_gotest(self):
+        yield from self._testFile('normal_test.go', 5)
+        self.assertLastCommand('dlv test ./. -- -test.run \'TestNumbers$\'')
+
+        self._testLine(9)
+        self.assertLastCommand('dlv test ./. -- -test.run \'Testテスト$\'')
+
+        self._testLine(13)
+        self.assertLastCommand('dlv test ./. -- -test.run \'ExampleSomething$\'')
+
+    def test_line_ginkgo(self):
+        yield from self._testFile('ginkgo_test.go', 17)
+        self.assertLastCommand(
+            'dlv test ./. -- -ginkgo.focus=\'should paginate the result\''
+        )
+
+    def test_line_subdirectory(self):
+        yield from self._testFile(('mypackage', 'normal_test.go'), 5)
+        self.assertLastCommand('dlv test ./mypackage -- -test.run \'TestNumbers$\'')
+
+        self._testLine(9)
+        self.assertLastCommand('dlv test ./mypackage -- -test.run \'Testテスト$\'')
+
+        self._testLine(13)
+        self.assertLastCommand(
+            'dlv test ./mypackage -- -test.run \'ExampleSomething$\''
+        )
+
+    def test_line_no_nearest(self):
+        yield from self._testFile('normal_test.go', 1)
+        self.assertLastCommand('dlv test')
+
+    def test_file(self):
+        yield from self._testFile('normal_test.go')
+        self.assertLastCommand('dlv test')
+
+    def test_file_subdirectory(self):
+        yield from self._testFile('mypackage/normal_test.go')
+        self.assertLastCommand('dlv test ./mypackage/...')
+
+    def test_suite(self):
+        yield from self._testSuite('normal_test.go')
+        self.assertLastCommand('dlv test ./...')

--- a/tests/test_frameworks/go/test_ginkgo.py
+++ b/tests/test_frameworks/go/test_ginkgo.py
@@ -1,0 +1,59 @@
+from AnyTest.tests import SublimeProjectTestCase
+
+
+class GinkgoTestCase(SublimeProjectTestCase):
+    folder = 'ginkgo'
+    settings = {'go.test_framework': 'ginkgo'}
+
+    def test_line(self):
+        yield from self._testFile('normal_test.go', 17)
+        self.assertLastCommand('ginkgo --focus=\'should paginate the result\' ./.')
+
+        self._testLine(29)
+        self.assertLastCommand('ginkgo --focus=\'user is not logged in\' ./.')
+
+        self._testLine(11)
+        self.assertLastCommand(
+            'ginkgo --focus=\'when the request is authenticated\' ./.'
+        )
+
+        self._testLine(9)
+        self.assertLastCommand('ginkgo --focus=\'posts API\' ./.')
+
+    def test_line_subdirectory(self):
+        yield from self._testFile(('mypackage', 'normal_test.go'), 17)
+        self.assertLastCommand(
+            'ginkgo --focus=\'should paginate the result\' ./mypackage'
+        )
+
+    def test_line_no_nearest(self):
+        yield from self._testFile(('mypackage', 'normal_test.go'), 1)
+        self.assertLastCommand(
+            'ginkgo --focus-file=', ('mypackage', 'normal_test.go'), ' ./mypackage'
+        )
+
+    def test_file(self):
+        yield from self._testFile('normal_test.go')
+        self.assertLastCommand('ginkgo --focus-file=normal_test.go ./.')
+
+    def test_file_subdirectory(self):
+        yield from self._testFile(('mypackage', 'normal_test.go'))
+        self.assertLastCommand(
+            'ginkgo --focus-file=', ('mypackage', 'normal_test.go'), ' ./mypackage'
+        )
+
+    def test_suite(self):
+        yield from self._testSuite('normal_test.go')
+        self.assertLastCommand('ginkgo ./.')
+
+    def test_suite_package(self):
+        yield from self._testSuite(('mypackage', 'normal_test.go'))
+        self.assertLastCommand('ginkgo ./mypackage')
+
+
+class GinkgoAutodetectionTestCase(SublimeProjectTestCase):
+    folder = 'ginkgo'
+
+    def test_line(self):
+        yield from self._testFile('normal_test.go', 17)
+        self.assertLastCommand('ginkgo --focus=\'should paginate the result\' ./.')

--- a/tests/test_frameworks/go/test_gotest.py
+++ b/tests/test_frameworks/go/test_gotest.py
@@ -29,6 +29,19 @@ class GotestTestCase(SublimeProjectTestCase):
         self._testLine(36)
         self.assertLastCommand('go test -run TestSomethingInASuite$ ./.')
 
+    def test_line_subdirectory(self):
+        yield from self._testFile(('mypackage', 'normal_test.go'), 5)
+        self.assertLastCommand('go test -run TestNumbers$ ./mypackage')
+
+        self._testLine(9)
+        self.assertLastCommand('go test -run Testテスト$ ./mypackage')
+
+        self._testLine(13)
+        self.assertLastCommand('go test -run ExampleSomething$ ./mypackage')
+
+        self._testLine(22)
+        self.assertLastCommand('go test -run TestSomething$ ./mypackage')
+
     def test_line_build_tags(self):
         yield from self._testFile('build_tags_test.go', 14)
         self.assertLastCommand(

--- a/tests/test_frameworks/go/test_gotest.py
+++ b/tests/test_frameworks/go/test_gotest.py
@@ -28,6 +28,12 @@ class GoTestTestCase(SublimeProjectTestCase):
         self._testLine(36)
         self.assertLastCommand('go test -run TestSomethingInASuite$ ./.')
 
+    def test_line_build_tags(self):
+        yield from self._testFile('build_tags_test.go', 14)
+        self.assertLastCommand(
+            'go test -run TestNumbers$ -tags=foo,hello,world,!bar,red,black ./.'
+        )
+
     def test_file(self):
         yield from self._testFile('normal_test.go')
         self.assertLastCommand('go test')
@@ -36,6 +42,14 @@ class GoTestTestCase(SublimeProjectTestCase):
         yield from self._testFile('mypackage/normal_test.go')
         self.assertLastCommand('go test ./mypackage/...')
 
+    def test_file_build_tags(self):
+        yield from self._testFile('build_tags_test.go')
+        self.assertLastCommand('go test -tags=foo,hello,world,!bar,red,black')
+
     def test_suite(self):
         yield from self._testSuite('normal_test.go')
+        self.assertLastCommand('go test ./...')
+
+    def test_suite_build_tags(self):
+        yield from self._testSuite('build_tags_test.go')
         self.assertLastCommand('go test ./...')

--- a/tests/test_frameworks/go/test_gotest.py
+++ b/tests/test_frameworks/go/test_gotest.py
@@ -1,0 +1,41 @@
+from AnyTest.tests import SublimeProjectTestCase
+
+
+class GoTestTestCase(SublimeProjectTestCase):
+    folder = 'gotest'
+
+    def test_line(self):
+        yield from self._testFile('normal_test.go', 5)
+        self.assertLastCommand('go test -run TestNumbers\\$ ./.')
+
+        self._testLine(8)
+        self.assertLastCommand('go test -run TestNumbers/adding_two_numbers\\$ ./.')
+
+        self._testLine(12)
+        self.assertLastCommand(
+            r'go test -run TestNumbers/\\\[\\\]\\\.\\\*\\\+\\\?\\\\\|\\\\\$\\\^\\\\\(\\\\\)\$ ./.'
+        )
+
+        self._testLine(17)
+        self.assertLastCommand('go test -run TestNumbers/this_is/nested\\$ ./.')
+
+        self._testLine(23)
+        self.assertLastCommand('go test -run Testテスト\\$ ./.')
+
+        self._testLine(27)
+        self.assertLastCommand('go test -run ExampleSomething\\$ ./.')
+
+        self._testLine(36)
+        self.assertLastCommand('go test -run TestSomethingInASuite\\$ ./.')
+
+    def test_file(self):
+        yield from self._testFile('normal_test.go')
+        self.assertLastCommand('go test')
+
+    def test_file_subdirectory(self):
+        yield from self._testFile('mypackage/normal_test.go')
+        self.assertLastCommand('go test ./mypackage/...')
+
+    def test_suite(self):
+        yield from self._testSuite('normal_test.go')
+        self.assertLastCommand('go test ./...')

--- a/tests/test_frameworks/go/test_gotest.py
+++ b/tests/test_frameworks/go/test_gotest.py
@@ -6,27 +6,27 @@ class GoTestTestCase(SublimeProjectTestCase):
 
     def test_line(self):
         yield from self._testFile('normal_test.go', 5)
-        self.assertLastCommand('go test -run TestNumbers\\$ ./.')
+        self.assertLastCommand('go test -run TestNumbers$ ./.')
 
         self._testLine(8)
-        self.assertLastCommand('go test -run TestNumbers/adding_two_numbers\\$ ./.')
+        self.assertLastCommand('go test -run TestNumbers/adding_two_numbers$ ./.')
 
         self._testLine(12)
         self.assertLastCommand(
-            r'go test -run TestNumbers/\\\[\\\]\\\.\\\*\\\+\\\?\\\\\|\\\\\$\\\^\\\\\(\\\\\)\$ ./.'
+            r'go test -run TestNumbers/\\\[\\\]\\\.\\\*\\\+\\\?\\\|\\\$\\\^\\\(\\\)$ ./.'
         )
 
         self._testLine(17)
-        self.assertLastCommand('go test -run TestNumbers/this_is/nested\\$ ./.')
+        self.assertLastCommand('go test -run TestNumbers/this_is/nested$ ./.')
 
         self._testLine(23)
-        self.assertLastCommand('go test -run Testテスト\\$ ./.')
+        self.assertLastCommand('go test -run Testテスト$ ./.')
 
         self._testLine(27)
-        self.assertLastCommand('go test -run ExampleSomething\\$ ./.')
+        self.assertLastCommand('go test -run ExampleSomething$ ./.')
 
         self._testLine(36)
-        self.assertLastCommand('go test -run TestSomethingInASuite\\$ ./.')
+        self.assertLastCommand('go test -run TestSomethingInASuite$ ./.')
 
     def test_file(self):
         yield from self._testFile('normal_test.go')

--- a/tests/test_frameworks/go/test_gotest.py
+++ b/tests/test_frameworks/go/test_gotest.py
@@ -1,8 +1,9 @@
 from AnyTest.tests import SublimeProjectTestCase
 
 
-class GoTestTestCase(SublimeProjectTestCase):
+class GotestTestCase(SublimeProjectTestCase):
     folder = 'gotest'
+    settings = {'go.test_framework': 'gotest'}
 
     def test_line(self):
         yield from self._testFile('normal_test.go', 5)

--- a/tests/test_frameworks/javascript/test_jest.py
+++ b/tests/test_frameworks/javascript/test_jest.py
@@ -18,7 +18,7 @@ class JestTestCase(SublimeProjectTestCase):
 
         self._testLine(4)
         self.assertLastCommand(
-            'jest --no-coverage -t \'^Math Addition adds two numbers\\$\' -- ',
+            'jest --no-coverage -t \'^Math Addition adds two numbers$\' -- ',
             ('__tests__', 'normal-test.js'),
         )
 
@@ -36,7 +36,7 @@ class JestTestCase(SublimeProjectTestCase):
 
         self._testLine(3)
         self.assertLastCommand(
-            'jest --no-coverage -t \'^Math Addition adds two numbers\\$\' -- ',
+            'jest --no-coverage -t \'^Math Addition adds two numbers$\' -- ',
             ('__tests__', 'context-test.js'),
         )
 
@@ -54,7 +54,7 @@ class JestTestCase(SublimeProjectTestCase):
 
         self._testLine(3)
         self.assertLastCommand(
-            'jest --no-coverage -t \'^Math Addition adds two numbers\\$\' -- ',
+            'jest --no-coverage -t \'^Math Addition adds two numbers$\' -- ',
             ('__tests__', 'normal-test.coffee'),
         )
 
@@ -72,7 +72,7 @@ class JestTestCase(SublimeProjectTestCase):
 
         self._testLine(3)
         self.assertLastCommand(
-            'jest --no-coverage -t \'^Math Addition adds two numbers\\$\' -- ',
+            'jest --no-coverage -t \'^Math Addition adds two numbers$\' -- ',
             ('__tests__', 'normal-test.jsx'),
         )
 

--- a/tests/test_frameworks/javascript/test_mocha.py
+++ b/tests/test_frameworks/javascript/test_mocha.py
@@ -127,11 +127,7 @@ class MochaJavaScriptTestCase(SublimeProjectTestCase):
 
 class MochaTypeScriptTestCase(SublimeProjectTestCase):
     folder = ('mocha', 'typescript')
-
-    def setUp(self):
-        super().setUp()
-
-        self.setSettings({'javascript.test_framework': 'mocha'})
+    settings = {'javascript.test_framework': 'mocha'}
 
     def test_line(self):
         yield from self._testFile(('test', 'normal.ts'), 2)

--- a/tests/test_frameworks/javascript/test_mocha.py
+++ b/tests/test_frameworks/javascript/test_mocha.py
@@ -17,7 +17,7 @@ class MochaJavaScriptTestCase(SublimeProjectTestCase):
         self.assertLastCommand(
             'mocha ',
             ('test', 'normal.js'),
-            ' --grep \'^Math Addition adds two numbers\\$\'',
+            ' --grep \'^Math Addition adds two numbers$\'',
         )
 
     def test_line_context(self):
@@ -33,7 +33,7 @@ class MochaJavaScriptTestCase(SublimeProjectTestCase):
         self.assertLastCommand(
             'mocha ',
             ('test', 'context.js'),
-            ' --grep \'^Math Addition adds two numbers\\$\'',
+            ' --grep \'^Math Addition adds two numbers$\'',
         )
 
     def test_list_coffee(self):
@@ -49,7 +49,7 @@ class MochaJavaScriptTestCase(SublimeProjectTestCase):
         self.assertLastCommand(
             'mocha ',
             ('test', 'normal.coffee'),
-            ' --grep \'^Math Addition adds two numbers\\$\'',
+            ' --grep \'^Math Addition adds two numbers$\'',
         )
 
     def test_line_react(self):
@@ -65,7 +65,7 @@ class MochaJavaScriptTestCase(SublimeProjectTestCase):
         self.assertLastCommand(
             'mocha ',
             ('test', 'normal.jsx'),
-            ' --grep \'^Math Addition adds two numbers\\$\'',
+            ' --grep \'^Math Addition adds two numbers$\'',
         )
 
     def test_line_typescript(self):
@@ -81,7 +81,7 @@ class MochaJavaScriptTestCase(SublimeProjectTestCase):
         self.assertLastCommand(
             'mocha ',
             ('test', 'normal.ts'),
-            ' --grep \'^Math Addition adds two numbers\\$\'',
+            ' --grep \'^Math Addition adds two numbers$\'',
         )
 
     def test_line_typescript_jsx(self):
@@ -97,7 +97,7 @@ class MochaJavaScriptTestCase(SublimeProjectTestCase):
         self.assertLastCommand(
             'mocha ',
             ('test', 'normal.tsx'),
-            ' --grep \'^Math Addition adds two numbers\\$\'',
+            ' --grep \'^Math Addition adds two numbers$\'',
         )
 
     def test_line_no_nearest(self):
@@ -158,7 +158,7 @@ class MochaTypeScriptTestCase(SublimeProjectTestCase):
             ('ts-node', 'register'),
             ' ',
             ('test', 'normal.ts'),
-            ' --grep \'^Math Addition adds two numbers\\$\'',
+            ' --grep \'^Math Addition adds two numbers$\'',
         )
 
     def test_line_jsx(self):
@@ -186,7 +186,7 @@ class MochaTypeScriptTestCase(SublimeProjectTestCase):
             ('ts-node', 'register'),
             ' ',
             ('test', 'normal.tsx'),
-            ' --grep \'^Math Addition adds two numbers\\$\'',
+            ' --grep \'^Math Addition adds two numbers$\'',
         )
 
     def test_line_no_nearest(self):

--- a/tests/test_frameworks/ruby/test_m.py
+++ b/tests/test_frameworks/ruby/test_m.py
@@ -3,11 +3,7 @@ from AnyTest.tests import SublimeProjectTestCase
 
 class MTestCase(SublimeProjectTestCase):
     folder = ('minitest', 'rake')
-
-    def setUp(self):
-        super().setUp()
-
-        self.setSettings({'ruby.minitest.use_m': True})
+    settings = {'ruby.minitest.use_m': True}
 
     def test_line(self):
         yield from self._testFile('classic_unit_test.rb', 3)

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -195,18 +195,6 @@ class FileTestCase(unittest.TestCase):
             self.assertFalse(File(subfolder, existing_dir).exists())
 
     @unittest.skipIf(IS_WINDOWS, '[Errno 13] Permission denied')
-    def test_contains(self):
-        with tempfile.NamedTemporaryFile('w') as tmpfile:
-            tmpfile.write('some content goes here')
-            tmpfile.seek(0)
-            file_name = os.path.basename(tmpfile.name)
-            root = Root(os.path.dirname(tmpfile.name))
-            file = File(root, file_name)
-
-            self.assertTrue(file.contains('content'))
-            self.assertFalse(file.contains('uNkn0wn'))
-
-    @unittest.skipIf(IS_WINDOWS, '[Errno 13] Permission denied')
     def test_lines(self):
         with tempfile.NamedTemporaryFile('w') as tmpfile:
             tmpfile.write('line1\nline2\nline3')
@@ -217,6 +205,18 @@ class FileTestCase(unittest.TestCase):
             lines = [line for line in file.lines()]
 
             self.assertEqual(lines, ['line1', 'line2', 'line3'])
+
+    @unittest.skipIf(IS_WINDOWS, '[Errno 13] Permission denied')
+    def test_contains_line(self):
+        with tempfile.NamedTemporaryFile('w') as tmpfile:
+            tmpfile.write('some content goes here')
+            tmpfile.seek(0)
+            file_name = os.path.basename(tmpfile.name)
+            root = Root(os.path.dirname(tmpfile.name))
+            file = File(root, file_name)
+
+            self.assertTrue(file.contains_line('content'))
+            self.assertFalse(file.contains_line('uNkn0wn'))
 
     def test_dir_relpath(self):
         root = Root(path('code', 'project'))

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -176,6 +176,14 @@ class RelativePathTestCase(unittest.TestCase):
 
         self.assertEqual(relative_path.name(), 'file')
 
+    def test_is_in_root(self):
+        root = Root(path('code', 'project'))
+        relative_path1 = RelativePath(root, 'file.py')
+        relative_path2 = RelativePath(root, 'folder', 'file.py')
+
+        self.assertTrue(relative_path1.is_in_root())
+        self.assertFalse(relative_path2.is_in_root())
+
 
 class FileTestCase(unittest.TestCase):
     def test_exists_checks_if_file_exists(self):
@@ -197,6 +205,24 @@ class FileTestCase(unittest.TestCase):
 
             self.assertTrue(file.contains('content'))
             self.assertFalse(file.contains('uNkn0wn'))
+
+    @unittest.skipIf(IS_WINDOWS, '[Errno 13] Permission denied')
+    def test_lines(self):
+        with tempfile.NamedTemporaryFile('w') as tmpfile:
+            tmpfile.write('line1\nline2\nline3')
+            tmpfile.seek(0)
+            file_name = os.path.basename(tmpfile.name)
+            root = Root(os.path.dirname(tmpfile.name))
+            file = File(root, file_name)
+            lines = [line for line in file.lines()]
+
+            self.assertEqual(lines, ['line1', 'line2', 'line3'])
+
+    def test_dir_relpath(self):
+        root = Root(path('code', 'project'))
+        relative_path = File(root, 'folder1', 'folder2', 'file.py')
+
+        self.assertEqual(relative_path.dir_relpath(), os.path.join('folder1', 'folder2'))
 
 
 class GlobTestCase(unittest.TestCase):

--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -222,7 +222,9 @@ class FileTestCase(unittest.TestCase):
         root = Root(path('code', 'project'))
         relative_path = File(root, 'folder1', 'folder2', 'file.py')
 
-        self.assertEqual(relative_path.dir_relpath(), os.path.join('folder1', 'folder2'))
+        self.assertEqual(
+            relative_path.dir_relpath(), os.path.join('folder1', 'folder2')
+        )
 
 
 class GlobTestCase(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import unittest
+
+from AnyTest.plugin.utils import escape_regex, replace
+
+
+class UtilsTestCase(unittest.TestCase):
+    def test_escape_regex(self):
+        self.assertEqual(
+            escape_regex('?+*\\^$.|{}[]()'), r'\?\+\*\\\^\$\.\|\{\}\[\]\(\)'
+        )
+        self.assertEqual(escape_regex('/'), '/')
+
+    def test_replace(self):
+        self.assertEqual(
+            replace('foo-bar_baz/qux', ('-', '_'), ('/', '_')),
+            'foo_bar_baz_qux',
+        )


### PR DESCRIPTION
- [x] `delve`
- [x] `ginkgo`
- [x] `gotest`
- [ ] ~`richgo`~ can be easily supported by updating the executable for the `gotest`